### PR TITLE
Add sourcemap support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,12 @@ const PLUGIN_NAME = 'gulp-file-transform-cache';
 // requirement of file-tranforme-cache. so just normalize...
 function normalizeVinyl(file) {
     if ( !File.isVinyl(file) ) {
-        return new File({path: file.path, base: file.base, contents: file.contents});
+        return new File({
+            path: file.path, 
+            base: file.base, 
+            contents: file.contents,
+            sourceMap: file.sourceMap
+        });
     }
     return file;
 }


### PR DESCRIPTION
Currently when converting to a file `.sourceMap` properties are removed from the file object. This allows sourceMap support.